### PR TITLE
Add subscribeEventedEffOn

### DIFF
--- a/src/Control/Reactive/EventEmitter.purs
+++ b/src/Control/Reactive/EventEmitter.purs
@@ -83,4 +83,27 @@ subscribeEventedOn n f o = subscribeEventedOnPrime n (\e ->
     f $ newEvent e."type" e."detail"
   ) o
 
+foreign import subscribeEventedEffOnPrime
+  "function subscribeEventedEffOnPrime(n){\
+  \ return function(fn){                  \
+  \    return function(obj){              \
+  \       return function(){              \
+  \         var fnE = function (event) {  \
+  \           return fn(event)();         \
+  \         };                            \
+  \         obj.addEventListener(n, fnE); \
+  \         return obj;                   \
+  \       };                              \
+  \     };                                \
+  \  };                                   \
+  \}" :: forall d a o e eff. 
+         String -> 
+         (d -> Eff eff a) -> 
+         o -> 
+         Eff (customEvent :: CustomEvent | eff) o
+
+subscribeEventedEffOn n f o = subscribeEventedEffOnPrime n (\e ->
+    f $ newEvent e."type" e."detail"
+  ) o
+
 unwrapDetail (Event n d) = d.detail

--- a/tests/Control/Reactive/EventEmitter.Spec.purs
+++ b/tests/Control/Reactive/EventEmitter.Spec.purs
@@ -10,7 +10,7 @@ import Debug.Foreign
 handler done d' event = do
   trace "what?"
   expect (unwrapDetail event) `toDeepEqual` d'
-  itIs done
+  return $ itIs done
 
 spec = do
   describe "Control.Monad.Event" $ do
@@ -35,6 +35,6 @@ spec = do
     itAsync "subscribeEventedOn should receive any attached data" $ \done -> do      
       w <- getWindow 
         
-      subscribeEventedOn "foo" (handler done d') w
+      subscribeEventedEffOn "foo" (handler done d') w
 
       emitOn sampleEvent w


### PR DESCRIPTION
So there's probably a slightly more elegant way of defining this so you don't have to duplicate the entire of `subscribeEventedOnPrime` for `subscribeEventedEffOnPrime`, but as you can see the changes are fairly minor.
